### PR TITLE
[MYO-24] Removed unused properties from event structs

### DIFF
--- a/game-lambda/src/events.rs
+++ b/game-lambda/src/events.rs
@@ -43,18 +43,12 @@ pub struct GameState {
     pub btime: u64,
     pub winc: u64,
     pub binc: u64,
-    pub wdraw: bool,
-    pub bdraw: bool,
     pub status: String,
 }
 
 #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct Player {
     pub id: String,
-    pub name: String,
-    pub title: Option<String>,
-    pub rating: usize,
-    pub provisional: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -118,8 +112,6 @@ mod test {
                         btime: 1000,
                         winc: 0,
                         binc: 0,
-                        wdraw: false,
-                        bdraw: false,
                         status: String::from("started")
                     },
                     state
@@ -170,26 +162,8 @@ mod test {
             Err(error) => panic!(format!("Parse error {:?}", error)),
             Ok(event) => match event {
                 GameEvent::GameFull { content } => {
-                    assert_eq!(
-                        Player {
-                            id: String::from("th0masb"),
-                            name: String::from("th0masb"),
-                            title: None,
-                            rating: 1500,
-                            provisional: true
-                        },
-                        content.white
-                    );
-                    assert_eq!(
-                        Player {
-                            id: String::from("myopic-bot"),
-                            name: String::from("myopic-bot"),
-                            title: Some(String::from("BOT")),
-                            rating: 1500,
-                            provisional: true
-                        },
-                        content.black
-                    );
+                    assert_eq!(Player { id: format!("th0masb") }, content.white);
+                    assert_eq!(Player { id: format!("myopic-bot") }, content.black);
                     assert_eq!(Clock { initial: 1200000, increment: 10000 }, content.clock);
                     assert_eq!(
                         GameState {
@@ -198,8 +172,6 @@ mod test {
                             btime: 1000,
                             winc: 0,
                             binc: 0,
-                            wdraw: false,
-                            bdraw: false,
                             status: String::from("started")
                         },
                         content.state

--- a/game-lambda/src/first_moves.rs
+++ b/game-lambda/src/first_moves.rs
@@ -1,8 +1,6 @@
-
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
-
 
 const SEP: &'static str = "|";
 const FIRST_MOVES: [(&str, &str); 21] = [

--- a/game-lambda/src/game.rs
+++ b/game-lambda/src/game.rs
@@ -4,7 +4,7 @@ use crate::first_moves::FirstMoveMap;
 use crate::helper::*;
 use crate::TimeConstraints;
 use myopic_board::MutBoard;
-use myopic_brain::{EvalBoard};
+use myopic_brain::EvalBoard;
 use myopic_core::Side;
 use reqwest::blocking::Client;
 


### PR DESCRIPTION
Removed some unused fields from the event struct which fixes issue of sometimes absent "provisional" flag for a players rating.