### PR TITLE
[ISSUE-37] Increase resiliency of event-stream poller

### DIFF
--- a/event-stream/src/main.rs
+++ b/event-stream/src/main.rs
@@ -1,9 +1,9 @@
-mod client;
 mod events;
 mod params;
+mod service;
 
-extern crate dotenv;
 extern crate bytes;
+extern crate dotenv;
 extern crate reqwest;
 extern crate serde;
 extern crate serde_json;
@@ -12,53 +12,68 @@ extern crate tokio;
 extern crate serde_derive;
 
 use crate::params::ApplicationParameters;
-use client::LichessClient;
 use events::LichessEvent;
 use reqwest::blocking;
+use service::LichessService;
 
 use simple_logger::SimpleLogger;
 
 use std::error::Error;
 use std::io::{BufRead, BufReader};
+use std::thread;
+use std::time::Duration;
 
 const EVENT_STREAM_ENDPOINT: &'static str = "https://lichess.org/api/stream/event";
 
 fn main() -> Result<(), Box<dyn Error>> {
-    dotenv::dotenv().ok();
-    SimpleLogger::new().with_level(log::LevelFilter::Info).init()?;
-
+    init_environment()?;
     let parameters = ApplicationParameters::load()?;
-    let client = LichessClient::new(parameters.clone());
 
-    log::info!("Opening event stream");
-    for read_result in open_event_stream(&parameters.lichess_auth_token)?.lines() {
-        match read_result {
-            Err(read_error) => log::warn!("Stream read error: {}", read_error),
-            Ok(line) => {
-                if !line.trim().is_empty() {
-                    match serde_json::from_str::<LichessEvent>(line.as_str()) {
-                        Err(parse_error) => log::warn!("Parse error: {}", parse_error),
-                        Ok(event) => match event {
-                            LichessEvent::Challenge { challenge } => {
-                                log::info!("Received challenge event: {}", line);
-                                match client.process_challenge(challenge) {
-                                    Ok(message) => {
-                                        log::info!("Processed challenge with message: {}", message)
-                                    }
-                                    Err(error) => log::warn!("Error processing challenge: {}", error),
-                                }
-                            }
-                            LichessEvent::GameStart { game: _ } => {
-                                log::info!("Received game start event: {}", line);
-                            }
-                        },
-                    }
-                }
-            },
+    loop {
+        let service = LichessService::new(parameters.clone());
+        log::info!("Opening event stream");
+        for read_result in open_event_stream(&parameters.lichess_auth_token)?.lines() {
+            handle_stream_read(&service, read_result)
         }
+
+        log::info!("Sleeping for {} seconds", parameters.retry_wait_duration_secs);
+        thread::sleep(Duration::from_secs(parameters.retry_wait_duration_secs));
     }
 
     Ok(())
+}
+
+fn init_environment() -> Result<(), Box<dyn Error>> {
+    dotenv::dotenv().ok();
+    SimpleLogger::new().with_level(log::LevelFilter::Info).init()?;
+    Ok(())
+}
+
+fn handle_stream_read(service: &LichessService, read_result: std::io::Result<String>) {
+    match read_result {
+        Err(read_error) => log::warn!("Stream read error: {}", read_error),
+        Ok(line) => {
+            if !line.trim().is_empty() {
+                match serde_json::from_str::<LichessEvent>(line.as_str()) {
+                    Err(parse_error) => log::warn!("Parse error: {}", parse_error),
+                    Ok(event) => match event {
+                        LichessEvent::Challenge { challenge } => {
+                            log::info!("Received challenge event: {}", line);
+                            match service.process_challenge(challenge) {
+                                Ok(message) => {
+                                    log::info!("Processed challenge with message: {}", message)
+                                }
+                                Err(error) => log::warn!("Error processing challenge: {}", error),
+                            }
+                        }
+                        LichessEvent::GameStart { game: _ } => {
+                            log::info!("Received game start event: {}", line);
+                        }
+                    },
+                }
+            }
+        }
+    }
 }
 
 fn open_event_stream(auth_token: &String) -> Result<BufReader<blocking::Response>, Box<dyn Error>> {

--- a/event-stream/src/params.rs
+++ b/event-stream/src/params.rs
@@ -21,6 +21,7 @@ const MYOPIC_MIN_INCREMENT_SECS: &'static str = "MYOPIC_MIN_INCREMENT_SECS";
 const MYOPIC_MAX_INCREMENT_SECS: &'static str = "MYOPIC_MAX_INCREMENT_SECS";
 const MYOPIC_MAX_LAMBDA_DURATION_MINS: &'static str = "MYOPIC_MAX_LAMBDA_DURATION_MINS";
 const MYOPIC_INCREMENT_ALLOWANCE_MINS: &'static str = "MYOPIC_INCREMENT_ALLOWANCE_MINS";
+const MYOPIC_RETRY_WAIT_DURATION_SECS: &'static str = "MYOPIC_RETRY_WAIT_DURATION_SECS";
 
 #[derive(Debug, Clone)]
 pub struct ApplicationParameters {
@@ -39,6 +40,7 @@ pub struct ApplicationParameters {
     pub max_increment_secs: u32,
     pub max_lambda_duration_mins: u8,
     pub increment_allowance_mins: u8,
+    pub retry_wait_duration_secs: u64,
 }
 
 impl ApplicationParameters {
@@ -59,6 +61,7 @@ impl ApplicationParameters {
             max_increment_secs: env::var(MYOPIC_MAX_INCREMENT_SECS)?.parse()?,
             max_lambda_duration_mins: env::var(MYOPIC_MAX_LAMBDA_DURATION_MINS)?.parse()?,
             increment_allowance_mins: env::var(MYOPIC_INCREMENT_ALLOWANCE_MINS)?.parse()?,
+            retry_wait_duration_secs: env::var(MYOPIC_RETRY_WAIT_DURATION_SECS)?.parse()?,
         })
     }
 

--- a/event-stream/src/service.rs
+++ b/event-stream/src/service.rs
@@ -10,14 +10,14 @@ use std::str::FromStr;
 const CHALLENGE_ENDPOINT: &'static str = "https://lichess.org/api/challenge";
 const STANDARD_VARIANT_KEY: &'static str = "standard";
 
-pub(super) struct LichessClient {
+pub(super) struct LichessService {
     parameters: ApplicationParameters,
     client: blocking::Client,
 }
 
-impl LichessClient {
-    pub(super) fn new(parameters: ApplicationParameters) -> LichessClient {
-        LichessClient { parameters, client: blocking::Client::new() }
+impl LichessService {
+    pub(super) fn new(parameters: ApplicationParameters) -> LichessService {
+        LichessService { parameters, client: blocking::Client::new() }
     }
 
     pub(super) fn process_challenge(&self, challenge: Challenge) -> Result<String, Box<dyn Error>> {


### PR DESCRIPTION
Now in the case of a broken connection the poller will sleep for a configurable amount of time before retrying ad infinium.

closes #37 