### PR TITLE
Separate move computation into a separate lambda

### DIFF
--- a/brain/Cargo.toml
+++ b/brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myopic-brain"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Thomas Ball <tomoliverball@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/brain/src/bench/middlegame.rs
+++ b/brain/src/bench/middlegame.rs
@@ -1,6 +1,6 @@
-use std::io::{BufReader, BufRead};
-use std::fs::File;
 use std::error::Error;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::time::Instant;
 
 #[rustfmt::skip]
@@ -31,7 +31,7 @@ fn benchmark() -> Result<(), Box<dyn Error>> {
         .lines()
         .take(max_positions)
         .map(|l| l.unwrap())
-        .map(|l| match crate::position(l.as_str()) {
+        .map(|l| match crate::pos::from_fen(l.as_str()) {
             Err(message) => panic!("{}", message),
             Ok(position) => position,
         })

--- a/brain/src/bench/mod.rs
+++ b/brain/src/bench/mod.rs
@@ -1,3 +1,2 @@
 mod mate_in_three;
 mod middlegame;
-

--- a/brain/src/eval.rs
+++ b/brain/src/eval.rs
@@ -1,7 +1,6 @@
-use crate::eval_impl::EvalBoardImpl;
 use crate::tables::PositionTables;
 use crate::values::PieceValues;
-use myopic_board::{MutBoard, MutBoardImpl, Piece, Square};
+use myopic_board::{MutBoard, Piece, Square};
 use serde_derive::{Deserialize, Serialize};
 
 /// The evaluation upper/lower bound definition
@@ -41,30 +40,6 @@ pub trait EvalBoard: MutBoard {
 /// Allows one to configure the parameters of the evaluation board.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Default)]
 pub struct EvalParameters {
-    piece_values: PieceValues,
-    position_tables: PositionTables,
-}
-
-/// Construct an instance of the default EvalBoard implementation using the
-/// position encoded as a fen string and the given parameters.
-pub fn position_and_params(
-    fen: &str,
-    params: EvalParameters,
-) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
-    myopic_board::fen_position(fen)
-        .map(|pos| EvalBoardImpl::new(pos, params.position_tables, params.piece_values))
-}
-
-/// Construct an instance of the default EvalBoard implementation using the
-/// default Board implementation from a fen string.
-pub fn position(fen: &str) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
-    position_and_params(fen, EvalParameters::default())
-}
-
-pub fn start() -> EvalBoardImpl<MutBoardImpl> {
-    EvalBoardImpl::new(
-        myopic_board::start_position(),
-        PositionTables::default(),
-        PieceValues::default(),
-    )
+    pub piece_values: PieceValues,
+    pub position_tables: PositionTables,
 }

--- a/brain/src/eval_impl.rs
+++ b/brain/src/eval_impl.rs
@@ -68,8 +68,8 @@ impl<B: MutBoard> EvalBoardImpl<B> {
             end_eval: compute_endgame(&board, &tables, &values),
             phase: compute_phase(&board),
             board,
-            piece_values: PieceValues::default(),
-            position_tables: PositionTables::default(),
+            piece_values: values,
+            position_tables: tables,
         }
     }
 

--- a/brain/src/lib.rs
+++ b/brain/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 
 mod eval;
 mod eval_impl;
+pub mod pos;
 mod quiescent;
 mod search;
 mod see;
@@ -13,7 +14,7 @@ pub mod values;
 #[cfg(test)]
 mod bench;
 
-pub use eval::{position, position_and_params, start, EvalBoard, EvalParameters};
+pub use eval::{EvalBoard, EvalParameters};
 pub use eval_impl::EvalBoardImpl;
 pub use myopic_board::*;
 

--- a/brain/src/pos.rs
+++ b/brain/src/pos.rs
@@ -1,0 +1,52 @@
+use crate::tables::PositionTables;
+use crate::values::PieceValues;
+use crate::{EvalBoardImpl, EvalParameters};
+use myopic_board::MutBoardImpl;
+
+/// Construct an instance of the default EvalBoard implementation using the
+/// position encoded as a fen string and the given parameters.
+pub fn from_fen_and_params(
+    fen: &str,
+    params: EvalParameters,
+) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    myopic_board::fen_position(fen)
+        .map(|inner| EvalBoardImpl::new(inner, params.position_tables, params.piece_values))
+}
+
+/// Construct an instance of the default EvalBoard implementation using the
+/// default Board implementation from a fen string.
+pub fn from_fen(fen: &str) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    from_fen_and_params(fen, EvalParameters::default())
+}
+
+pub fn from_pgn_and_params(
+    pgn_sequence: &str,
+    params: EvalParameters,
+) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    myopic_board::parse::position_from_pgn(pgn_sequence)
+        .map(|inner| EvalBoardImpl::new(inner, params.position_tables, params.piece_values))
+}
+
+pub fn from_pgn(pgn_sequence: &str) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    from_pgn_and_params(pgn_sequence, EvalParameters::default())
+}
+
+pub fn from_uci_and_params(
+    uci_sequence: &str,
+    params: EvalParameters,
+) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    myopic_board::parse::position_from_uci(uci_sequence)
+        .map(|inner| EvalBoardImpl::new(inner, params.position_tables, params.piece_values))
+}
+
+pub fn from_uci(uci_sequence: &str) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    from_uci_and_params(uci_sequence, EvalParameters::default())
+}
+
+pub fn start() -> EvalBoardImpl<MutBoardImpl> {
+    EvalBoardImpl::new(
+        myopic_board::start_position(),
+        PositionTables::default(),
+        PieceValues::default(),
+    )
+}

--- a/brain/src/search/mod.rs
+++ b/brain/src/search/mod.rs
@@ -185,7 +185,7 @@ mod test {
     const DEPTH: usize = 3;
 
     fn test(fen_string: &'static str, expected_move_pool: Vec<Move>, is_won: bool) {
-        let board = crate::eval::position(fen_string).unwrap();
+        let board = crate::pos::from_fen(fen_string).unwrap();
         let (ref_board, ref_move_pool) = (board.reflect(), expected_move_pool.reflect());
         test_impl(board, expected_move_pool, is_won);
         test_impl(ref_board, ref_move_pool, is_won);
@@ -195,7 +195,10 @@ mod test {
         match super::search(board, DEPTH) {
             Err(message) => panic!("{}", message),
             Ok(outcome) => {
-                assert!(expected_move_pool.contains(&outcome.best_move), serde_json::to_string(&outcome).unwrap());
+                assert!(
+                    expected_move_pool.contains(&outcome.best_move),
+                    serde_json::to_string(&outcome).unwrap()
+                );
                 if is_won {
                     assert_eq!(eval::WIN_VALUE, outcome.eval);
                 }

--- a/brain/src/search/ordering.rs
+++ b/brain/src/search/ordering.rs
@@ -55,7 +55,7 @@ impl<B: EvalBoard> MoveQualityEstimator<B> for EstimatorImpl {
             MoveCategory::GoodExchange(n) => 30_000 + n,
             MoveCategory::Special => 20_000,
             MoveCategory::Positional(n) => 10_000 + n,
-            MoveCategory::BadExchange(n) => n
+            MoveCategory::BadExchange(n) => n,
         }
     }
 }
@@ -74,7 +74,7 @@ fn get_category<B: EvalBoard>(board: &mut B, mv: &Move) -> MoveCategory {
     match mv {
         Enpassant(..) | Castle(..) | Promotion(..) => MoveCategory::Special,
         &Standard(p, src, dst) => {
-            if  board.side(p.side().reflect()).contains(dst) {
+            if board.side(p.side().reflect()).contains(dst) {
                 let exchange_value =
                     crate::see::exchange_value(board, src, dst, board.piece_values());
                 if exchange_value > 0 {
@@ -137,4 +137,3 @@ fn parity(side: Side) -> i32 {
         Side::Black => -1,
     }
 }
-

--- a/deploy/bin/deploy.ts
+++ b/deploy/bin/deploy.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from '@aws-cdk/core';
-import { MyopicGameLambdaStack } from '../lib/myopic-game-lambda-stack';
+import { MyopicLambdaStack } from '../lib/myopic-lambda-stack';
 import { MyopicDatabaseStack } from "../lib/opening-db-stack";
 
 require('dotenv').config()
@@ -19,7 +19,7 @@ new MyopicDatabaseStack(app, 'MyopicDatabaseStack', {
   }
 });
 
-new MyopicGameLambdaStack(app, 'MyopicGameLambdaStack', {
+new MyopicLambdaStack(app, 'MyopicLambdaStack', {
   openingsTableName: process.env.OPENINGS_TABLE_NAME!,
   region: process.env.REGION!,
   account: process.env.ACCOUNT!,
@@ -38,5 +38,11 @@ new MyopicGameLambdaStack(app, 'MyopicGameLambdaStack', {
     functionName: process.env.BENCHMARK_FUNCTION_NAME!,
     timeout: cdk.Duration.minutes(Number.parseInt(process.env.BENCHMARK_FUNCTION_TIMEOUT_MINS!)),
     memoryLimit: Number.parseInt(process.env.BENCHMARK_MEMORY_SIZE!),
+  },
+  moveLambdaConfig: {
+    assetName: process.env.MOVE_ASSET_NAME!,
+    functionName: process.env.MOVE_FUNCTION_NAME!,
+    timeout: cdk.Duration.minutes(Number.parseInt(process.env.MOVE_FUNCTION_TIMEOUT_MINS!)),
+    memoryLimit: Number.parseInt(process.env.MOVE_MEMORY_SIZE!),
   }
 });

--- a/deploy/lib/myopic-lambda-stack.ts
+++ b/deploy/lib/myopic-lambda-stack.ts
@@ -4,12 +4,13 @@ import * as lambda from '@aws-cdk/aws-lambda';
 import * as iam from '@aws-cdk/aws-iam';
 import * as path from 'path';
 
-export interface MyopicGameLambdaStackProps extends cdk.StackProps {
+export interface MyopicLambdaStackProps extends cdk.StackProps {
   account: string
   region: string
   openingsTableName: string
   gameLambdaConfig: LambdaConfig
   benchLambdaConfig: LambdaConfig
+  moveLambdaConfig: LambdaConfig
 }
 
 export interface LambdaConfig {
@@ -21,9 +22,22 @@ export interface LambdaConfig {
 
 const HANDLER_NAME: string = "index.handler"
 
-export class MyopicGameLambdaStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props: MyopicGameLambdaStackProps) {
+export class MyopicLambdaStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props: MyopicLambdaStackProps) {
     super(scope, id, props);
+
+    // Create the move function
+    new lambda.Function(this, `${id}-MoveFn`, {
+      runtime: lambda.Runtime.PROVIDED_AL2,
+      handler: HANDLER_NAME,
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', 'runtime', props.moveLambdaConfig.assetName)
+      ),
+      functionName: props.moveLambdaConfig.functionName,
+      timeout: props.moveLambdaConfig.timeout,
+      retryAttempts: 0,
+      memorySize: props.moveLambdaConfig.memoryLimit,
+    })
 
     // Create the benchmarking function
     new lambda.Function(this, `${id}-BenchmarkFn`, {
@@ -39,7 +53,7 @@ export class MyopicGameLambdaStack extends cdk.Stack {
     });
 
     // Create the game handler function
-    const gameHandler = new lambda.Function(this, `${id}-Function`, {
+    const gameHandler = new lambda.Function(this, `${id}-GameFn`, {
       runtime: lambda.Runtime.PROVIDED_AL2,
       handler: HANDLER_NAME,
       code: lambda.Code.fromAsset(
@@ -51,12 +65,15 @@ export class MyopicGameLambdaStack extends cdk.Stack {
       memorySize: props.gameLambdaConfig.memoryLimit
     });
 
-    // Add permissions for recursive invoking of the function and access to the opening database
     const ps = new iam.PolicyStatement()
     ps.addActions("lambda:InvokeFunction", "dynamodb:GetItem")
     ps.addResources(
+      // Recursively invoke itself
       `arn:aws:lambda:${props.region}:${props.account}:function:${props.gameLambdaConfig.functionName}`,
-      `arn:aws:dynamodb:${props.region}:${props.account}:table/${props.openingsTableName}`
+      // Access the opening table
+      `arn:aws:dynamodb:${props.region}:${props.account}:table/${props.openingsTableName}`,
+      // Access the move lambda for computations
+        `arn:aws:lambda:${props.region}:${props.account}:function:${props.moveLambdaConfig.functionName}`,
     )
     gameHandler.addToRolePolicy(ps)
   }

--- a/game-lambda/src/compute.rs
+++ b/game-lambda/src/compute.rs
@@ -1,0 +1,98 @@
+use crate::game::ComputeService;
+use bytes::Bytes;
+use rusoto_core::Region;
+use rusoto_lambda::{InvocationRequest, Lambda, LambdaClient};
+use serde_derive::{Deserialize, Serialize};
+use simple_error::SimpleError;
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+pub struct LambdaMoveComputeService {
+    region: Region,
+    function_name: String,
+}
+impl Default for LambdaMoveComputeService {
+    fn default() -> Self {
+        LambdaMoveComputeService {
+            region: Region::EuWest2,
+            function_name: format!("MyopicMove"),
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+struct RequestPayload {
+    #[serde(rename = "type")]
+    payload_type: String,
+    sequence: String,
+    #[serde(rename = "timeoutMillis")]
+    timeout_millis: u64,
+}
+impl RequestPayload {
+    fn new(sequence: &str, limit: Duration) -> RequestPayload {
+        RequestPayload {
+            payload_type: format!("uciSequence"),
+            sequence: sequence.to_string(),
+            timeout_millis: limit.as_millis() as u64,
+        }
+    }
+}
+
+#[derive(Deserialize, Clone)]
+struct ResponsePayload {
+    #[serde(rename = "bestMove")]
+    best_move: String,
+    #[serde(rename = "depthSearched")]
+    depth_searched: usize,
+    #[serde(rename = "searchDurationMillis")]
+    search_duration_millis: u64,
+    eval: i32,
+}
+
+impl ComputeService for LambdaMoveComputeService {
+    fn compute_move(
+        &self,
+        uci_sequence: &str,
+        time_limit: Duration,
+    ) -> Result<String, Box<dyn Error>> {
+        let payload = serde_json::to_string(&RequestPayload::new(uci_sequence, time_limit))?;
+        log::info!("Request payload {}", payload);
+        let timer = Instant::now();
+        let invocation = tokio::runtime::Runtime::new().unwrap().block_on(
+            LambdaClient::new(self.region.clone()).invoke(InvocationRequest {
+                function_name: self.function_name.clone(),
+                payload: Some(Bytes::from(payload)),
+                client_context: None,
+                invocation_type: None,
+                log_type: None,
+                qualifier: None,
+            }),
+        )?;
+        log::info!("Response status: {:?}", invocation.status_code);
+        log::info!("Invocation took {}ms", timer.elapsed().as_millis());
+        match invocation.payload {
+            None => Err(Box::new(SimpleError::new("Missing response payload!")) as Box<dyn Error>),
+            Some(raw_bytes) => {
+                let decoded = String::from_utf8(raw_bytes.to_vec())?;
+                log::info!("Response payload: {}", decoded);
+                let response = serde_json::from_str::<ResponsePayload>(decoded.as_str())?;
+                Ok(response.best_move)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+
+    #[test]
+    fn check_bytes_conversion() {
+        let input = r#"{"someJson": "string", "n": 5}"#.to_string();
+        let bytes = Bytes::from(input.clone());
+        assert_eq!(
+            input,
+            String::from_utf8(bytes.to_vec()).expect("Unable to decode bytes!")
+        )
+    }
+}

--- a/game-lambda/src/helper.rs
+++ b/game-lambda/src/helper.rs
@@ -1,4 +1,4 @@
-use myopic_brain::{parse, EvalBoardImpl, Move, MutBoard, MutBoardImpl, Piece};
+use myopic_brain::{parse, EvalBoardImpl, MutBoard, MutBoardImpl};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub fn timestamp_millis() -> u64 {
@@ -75,77 +75,6 @@ mod thinking_time_test {
             initial: Duration::from_secs(600),
         };
         assert_eq!(Duration::from_millis(3250), compute_thinking_time(params))
-    }
-}
-
-pub fn move_to_uci(mv: &Move) -> String {
-    match mv {
-        &Move::Standard(_, src, dest) => format!("{}{}", src, dest),
-        &Move::Enpassant(src, dest) => format!("{}{}", src, dest),
-        &Move::Promotion(src, dest, piece) => format!(
-            "{}{}{}",
-            src,
-            dest,
-            match piece {
-                Piece::WQ | Piece::BQ => "q",
-                Piece::WR | Piece::BR => "r",
-                Piece::WB | Piece::BB => "b",
-                Piece::WN | Piece::BN => "n",
-                _ => "",
-            }
-        ),
-        &Move::Castle(zone) => {
-            let (_, src, dest) = zone.king_data();
-            format!("{}{}", src, dest)
-        }
-    }
-    .to_lowercase()
-    .to_owned()
-}
-
-#[cfg(test)]
-mod uci_conversion_test {
-    use super::move_to_uci;
-    use myopic_brain::{CastleZone, Move, Piece, Square};
-
-    #[test]
-    fn test_pawn_standard_conversion() {
-        assert_eq!(
-            "e2e4",
-            move_to_uci(&Move::Standard(Piece::WP, Square::E2, Square::E4)).as_str()
-        );
-    }
-
-    #[test]
-    fn test_rook_standard_conversion() {
-        assert_eq!(
-            "h1h7",
-            move_to_uci(&Move::Standard(Piece::BR, Square::H1, Square::H7)).as_str()
-        );
-    }
-
-    #[test]
-    fn test_castling_conversion() {
-        assert_eq!("e1g1", move_to_uci(&Move::Castle(CastleZone::WK)).as_str());
-        assert_eq!("e1c1", move_to_uci(&Move::Castle(CastleZone::WQ)).as_str());
-        assert_eq!("e8g8", move_to_uci(&Move::Castle(CastleZone::BK)).as_str());
-        assert_eq!("e8c8", move_to_uci(&Move::Castle(CastleZone::BQ)).as_str());
-    }
-
-    #[test]
-    fn test_promotion_conversion() {
-        assert_eq!(
-            "e7d8q",
-            move_to_uci(&Move::Promotion(Square::E7, Square::D8, Piece::WQ))
-        )
-    }
-
-    #[test]
-    fn test_enpassant_conversion() {
-        assert_eq!(
-            "e5d6",
-            move_to_uci(&Move::Enpassant(Square::E5, Square::D6))
-        )
     }
 }
 

--- a/move-lambda/Cargo.lock
+++ b/move-lambda/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -377,7 +377,7 @@ dependencies = [
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -405,7 +405,7 @@ dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_runtime_errors_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -511,52 +511,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-lambda"
+version = "0.1.0"
+dependencies = [
+ "lambda_runtime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "myopic-brain 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_logger 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "myopic-board"
-version = "1.0.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "myopic-core 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "myopic-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "myopic-brain"
-version = "1.1.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "myopic-board 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "myopic-core 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "myopic-board 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "myopic-core"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "myopic-move-lambda"
-version = "0.1.0"
-dependencies = [
- "lambda_runtime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "myopic-board 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "myopic-brain 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "myopic-core 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1245,9 +1245,9 @@ dependencies = [
 "checksum mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)" = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 "checksum mio-uds 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum myopic-board 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc78cb4f68718fb4a9b6023ff114e90dca816f47f79c8f3d935bd75394ceff4f"
-"checksum myopic-brain 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e630c798b9a6b7499ec5448d8854f0fbab7cd5937077ecdb145652609173a3b0"
-"checksum myopic-core 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e9bbeea044da027c65b112574aec5803831911562abafa31f8df9bea723d5134"
+"checksum myopic-board 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2cbf3f7892dac88f609ec8ad1417a44c6106ff790586e6d5649822868528c7bc"
+"checksum myopic-brain 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "648720c0faef7e5a7bbafc28201c5d4e63b89fe99fa9bda32e0ad9d00f509263"
+"checksum myopic-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e506c1444610c6df86bfaf4f0547f30a62824d1e6087857b8b032568c74376f2"
 "checksum net2 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
@@ -1281,7 +1281,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 "checksum serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
-"checksum serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)" = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+"checksum serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)" = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 "checksum simple-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "634bf7bc1315698154cb1b45c1db17fcd2e5ce41f925b7b4063e971536714bf1"
 "checksum simple_logger 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a53ed2efd04911c8280f2da7bf9abd350c931b86bc7f9f2386fbafbf525ff9"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"

--- a/move-lambda/Cargo.toml
+++ b/move-lambda/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "myopic-move-lambda"
+name = "move-lambda"
 version = "0.1.0"
 authors = ["Thomas Ball <tomoliverball@gmail.com>"]
 edition = "2018"
@@ -7,9 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-myopic-brain = "1.1.0"
-myopic-board = "1.0.1"
-myopic-core = "1.0.1"
+myopic-brain = "1.5.1"
 lambda_runtime = "0.2.1"
 serde_derive = "1.0.115"
 serde = "1.0.115"

--- a/move-lambda/src/main.rs
+++ b/move-lambda/src/main.rs
@@ -1,16 +1,78 @@
 use lambda_runtime::{error::HandlerError, lambda, Context};
-use myopic_board::Move;
-use myopic_brain::{eval::new_board, search};
-use myopic_core::castlezone::CastleZone;
+use myopic_brain::negamax::SearchContext;
+use myopic_brain::{EvalBoardImpl, MutBoardImpl};
 use serde_derive::{Deserialize, Serialize};
 use simple_error::bail;
 use simple_logger::SimpleLogger;
-use std::cmp::min;
 use std::error::Error;
 use std::time::Duration;
 
-// Five minutes in ms, don't want this lambda to take too long.
-const MAX_EXECUTION_MILLIS: u64 = 5 * 60 * 1000;
+const DEFAULT_TIMEOUT_MILLIS: u64 = 1000;
+const DEFAULT_MAX_DEPTH: usize = 10;
+
+/// Input payload
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
+enum ComputeMoveEvent {
+    #[serde(rename = "fen")]
+    Fen {
+        #[serde(flatten)]
+        terminator: SearchTerminator,
+        position: String,
+    },
+
+    #[serde(rename = "uciSequence")]
+    UciSequence {
+        #[serde(flatten)]
+        terminator: SearchTerminator,
+        sequence: String,
+    },
+}
+
+#[derive(Deserialize, Debug, Copy, Clone)]
+struct SearchTerminator {
+    #[serde(rename = "maxDepth", default)]
+    max_depth: MaxDepth,
+    #[serde(rename = "timeoutMillis", default)]
+    timeout_millis: TimeoutMillis,
+}
+impl myopic_brain::SearchTerminator for SearchTerminator {
+    fn should_terminate(&self, ctx: &SearchContext) -> bool {
+        (
+            Duration::from_millis(self.timeout_millis.0),
+            self.max_depth.0,
+        )
+            .should_terminate(ctx)
+    }
+}
+
+#[derive(Deserialize, Debug, Copy, Clone)]
+struct MaxDepth(usize);
+impl Default for MaxDepth {
+    fn default() -> Self {
+        MaxDepth(DEFAULT_MAX_DEPTH)
+    }
+}
+
+#[derive(Deserialize, Debug, Copy, Clone)]
+struct TimeoutMillis(u64);
+impl Default for TimeoutMillis {
+    fn default() -> Self {
+        TimeoutMillis(DEFAULT_TIMEOUT_MILLIS)
+    }
+}
+
+/// Output payload
+#[derive(Serialize, Clone)]
+struct ComputeMoveOutput {
+    #[serde(rename = "bestMove")]
+    best_move: String,
+    #[serde(rename = "depthSearched")]
+    depth_searched: usize,
+    #[serde(rename = "searchDurationMillis")]
+    search_duration_millis: u64,
+    eval: i32,
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     SimpleLogger::new()
@@ -20,51 +82,36 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[derive(Deserialize, Clone)]
-struct ComputeMoveEvent {
-    position: String,
-    #[serde(rename = "maxTimeMillis")]
-    max_time_millis: u64,
-    #[serde(rename = "maxDepth")]
-    max_depth: usize,
-}
-
-#[derive(Serialize, Clone)]
-struct ComputeMoveOutput {
-    #[serde(rename = "bestMove")]
-    best_move: String,
-    #[serde(rename = "depthSearched")]
-    depth_searched: usize,
-    #[serde(rename = "searchDurationMillis")]
-    search_duration_millis: u64,
-    evaluation: i32,
-}
-
 fn move_compute_handler(
     e: ComputeMoveEvent,
     _ctx: Context,
 ) -> Result<ComputeMoveOutput, HandlerError> {
-    let max_duration = Duration::from_millis(min(e.max_time_millis, MAX_EXECUTION_MILLIS));
-    let search_terminator = (max_duration, e.max_depth);
-    match new_board(e.position.as_str()).and_then(|board| search(board, search_terminator)) {
-        Err(message) => bail!(message.as_str()),
-        Ok(outcome) => Ok(ComputeMoveOutput {
-            best_move: stringify_move(outcome.best_move),
+    let terminator = extract_terminator(&e);
+    let position = extract_position(&e)?;
+    myopic_brain::search(position, terminator)
+        .map(|outcome| ComputeMoveOutput {
+            best_move: outcome.best_move.uci_format(),
             depth_searched: outcome.depth,
-            evaluation: outcome.eval,
+            eval: outcome.eval,
             search_duration_millis: outcome.time.as_millis() as u64,
-        }),
+        })
+        .map_err(|message| HandlerError::from(message.as_str()))
+}
+
+fn extract_position(e: &ComputeMoveEvent) -> Result<EvalBoardImpl<MutBoardImpl>, HandlerError> {
+    match e {
+        ComputeMoveEvent::Fen { position, .. } => myopic_brain::pos::from_fen(position.as_str())
+            .map_err(|e| HandlerError::from(e.as_str())),
+        ComputeMoveEvent::UciSequence { sequence, .. } => {
+            myopic_brain::pos::from_uci(sequence.as_str())
+                .map_err(|e| HandlerError::from(e.as_str()))
+        }
     }
 }
 
-fn stringify_move(mv: Move) -> String {
-    match mv {
-        Move::Standard(_, src, dest) => format!("{}{}", src, dest).to_lowercase(),
-        Move::Promotion(src, dest, piece) => format!("{}{}{:?}", src, dest, piece).to_lowercase(),
-        Move::Enpassant(src, dest) => format!("{}{}", src, dest).to_lowercase(),
-        Move::Castle(zone) => match zone {
-            CastleZone::WK | CastleZone::BK => String::from("O-O"),
-            CastleZone::WQ | CastleZone::BQ => String::from("O-O-O"),
-        },
+fn extract_terminator(e: &ComputeMoveEvent) -> SearchTerminator {
+    match e {
+        ComputeMoveEvent::Fen { terminator, .. } => *terminator,
+        ComputeMoveEvent::UciSequence { terminator, .. } => *terminator,
     }
 }


### PR DESCRIPTION
Instead of computing the next move inside the game-lambda we now make a call out to the move-lambda. This is a significantly more efficient use of resources as computing the move is the only cpu intensive part of playing the game.

closes #71 