### PR TITLE
Added alternative timings calculator

### DIFF
--- a/game-lambda/src/helper.rs
+++ b/game-lambda/src/helper.rs
@@ -1,81 +1,11 @@
 use myopic_brain::{parse, EvalBoardImpl, MutBoard, MutBoardImpl};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn timestamp_millis() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
         .as_millis() as u64
-}
-
-pub struct ThinkingTimeParams {
-    pub expected_half_move_count: u32,
-    pub half_moves_played: u32,
-    pub initial: Duration,
-    pub increment: Duration,
-}
-
-pub fn compute_thinking_time(params: ThinkingTimeParams) -> Duration {
-    // Lets say we predict a chess game will last n moves before the game. Lets say the
-    // time limit for the whole game is T seconds. Then for the first n / 2 moves allocate
-    // T / n seconds. For the next n / 2 moves allocate T / 2n seconds and so on.
-    //
-    // So for move m, define i = m // (n / 2) and we allocate t_m = T / n * 2^i seconds
-    //
-    // This can be modified to make the decrease in thinking time less sharp
-    let i = params.half_moves_played / (params.expected_half_move_count / 2);
-    let n = params.expected_half_move_count;
-    params.increment + (params.initial / (2u32.pow(i) * n))
-}
-
-#[cfg(test)]
-mod thinking_time_test {
-    use super::{compute_thinking_time, ThinkingTimeParams};
-    use std::time::Duration;
-
-    #[test]
-    fn test_first_move_of_first_period() {
-        let params = ThinkingTimeParams {
-            expected_half_move_count: 60,
-            half_moves_played: 0,
-            increment: Duration::from_secs(2),
-            initial: Duration::from_secs(600),
-        };
-        assert_eq!(Duration::from_secs(12), compute_thinking_time(params))
-    }
-
-    #[test]
-    fn test_first_move_of_second_period() {
-        let params = ThinkingTimeParams {
-            expected_half_move_count: 60,
-            half_moves_played: 30,
-            increment: Duration::from_secs(2),
-            initial: Duration::from_secs(600),
-        };
-        assert_eq!(Duration::from_secs(7), compute_thinking_time(params))
-    }
-
-    #[test]
-    fn test_first_move_of_third_period() {
-        let params = ThinkingTimeParams {
-            expected_half_move_count: 60,
-            half_moves_played: 60,
-            increment: Duration::from_secs(2),
-            initial: Duration::from_secs(600),
-        };
-        assert_eq!(Duration::from_millis(4500), compute_thinking_time(params))
-    }
-
-    #[test]
-    fn test_first_move_of_fourth_period() {
-        let params = ThinkingTimeParams {
-            expected_half_move_count: 60,
-            half_moves_played: 90,
-            increment: Duration::from_secs(2),
-            initial: Duration::from_secs(600),
-        };
-        assert_eq!(Duration::from_millis(3250), compute_thinking_time(params))
-    }
 }
 
 pub fn get_game_state(moves: &String) -> Result<(EvalBoardImpl<MutBoardImpl>, u32), String> {

--- a/game-lambda/src/main.rs
+++ b/game-lambda/src/main.rs
@@ -5,6 +5,7 @@ mod game;
 mod helper;
 mod lichess;
 mod messages;
+mod timing;
 
 use crate::compute::LambdaMoveComputeService;
 use crate::dynamodb::{DynamoDbOpeningService, DynamoDbOpeningServiceConfig};

--- a/game-lambda/src/timing.rs
+++ b/game-lambda/src/timing.rs
@@ -1,0 +1,176 @@
+use log::info;
+use tokio::time::Duration;
+
+pub struct Timing {
+    /// The function estimating how many
+    /// half moves remain in the game given
+    /// how many moves have been played
+    exp_moves_fn: fn(usize) -> f64,
+    /// Increment per move now
+    inc: Duration,
+    /// Any time added to computing a move
+    /// which is not spent thinking
+    move_latency: Duration,
+    /// Our minimum time to pass as a terminator to
+    /// the search function
+    min_compute_time: Duration,
+}
+impl Timing {
+    pub fn new(inc: Duration, move_latency: Duration, min_compute_time: Duration) -> Timing {
+        Timing {
+            exp_moves_fn: expected_half_moves_remaining,
+            inc,
+            move_latency,
+            min_compute_time,
+        }
+    }
+
+    pub fn compute_thinking_time(
+        &self,
+        half_moves_played: usize,
+        remaining_time: Duration,
+    ) -> Duration {
+        let estimated = if self.inc.as_secs() > 0 && remaining_time < self.inc_switch_buffer() {
+            info!(
+                "Remaining time {}ms is not enough to allocate anything above the increment",
+                remaining_time.as_millis()
+            );
+            self.inc - self.move_latency
+        } else {
+            // Divide by two because we need to think for half of the remaining moves
+            let exp_remaining = (self.exp_moves_fn)(half_moves_played) / 2f64;
+            info!(
+                "We have played {} half moves and expect to play {} more",
+                half_moves_played / 2,
+                exp_remaining
+            );
+            let allocated = ((remaining_time.as_millis() as f64) / exp_remaining).round() as u64;
+            Duration::from_millis(allocated) + self.inc - self.move_latency
+        };
+
+        if estimated > self.min_compute_time {
+            info!(
+                "Estimated we should spend {}ms thinking",
+                estimated.as_millis()
+            );
+            estimated
+        } else {
+            info!(
+                "Our estimate of {}ms was too low, defaulting to min of {}ms",
+                estimated.as_millis(),
+                self.min_compute_time.as_millis()
+            );
+            self.min_compute_time
+        }
+    }
+
+    fn inc_switch_buffer(&self) -> Duration {
+        5 * (self.min_compute_time + self.move_latency)
+    }
+}
+
+/// https://chess.stackexchange.com/questions/2506/what-is-the-average-length-of-a-game-of-chess
+fn expected_half_moves_remaining(moves_played: usize) -> f64 {
+    let k = moves_played as f64;
+    59.3 + (72830f64 - 2330f64 * k) / (2644f64 + k * (10f64 + k))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::timing::Timing;
+    use tokio::time::Duration;
+
+    fn dummy_half_moves_remaining(moves_played: usize) -> f64 {
+        moves_played as f64
+    }
+
+    #[test]
+    fn sub_1sec_inc_estimated_greater_than_min_returns_estimate_minus_latency() {
+        let timing = Timing {
+            exp_moves_fn: dummy_half_moves_remaining,
+            min_compute_time: Duration::from_millis(1100),
+            move_latency: Duration::from_millis(200),
+            inc: Duration::from_millis(999),
+        };
+
+        assert_eq!(
+            Duration::from_millis(4799),
+            timing.compute_thinking_time(20, Duration::from_secs(40))
+        );
+    }
+
+    #[test]
+    fn sub_1sec_inc_estimated_less_than_min_returns_min() {
+        let timing = Timing {
+            exp_moves_fn: dummy_half_moves_remaining,
+            min_compute_time: Duration::from_millis(1100),
+            move_latency: Duration::from_millis(200),
+            inc: Duration::from_millis(999),
+        };
+
+        assert_eq!(
+            Duration::from_millis(1100),
+            timing.compute_thinking_time(200, Duration::from_secs(10))
+        );
+    }
+
+    #[test]
+    fn sub_1sec_inc_time_remaining_less_than_inc_buffer_returns_estimate_minus_latency() {
+        let timing = Timing {
+            exp_moves_fn: dummy_half_moves_remaining,
+            min_compute_time: Duration::from_millis(100),
+            move_latency: Duration::from_millis(200),
+            inc: Duration::from_millis(999),
+        };
+
+        assert_eq!(
+            Duration::from_millis(809),
+            timing.compute_thinking_time(200, Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn eq_1sec_inc_estimated_greater_than_min_returns_estimate_minus_latency() {
+        let timing = Timing {
+            exp_moves_fn: dummy_half_moves_remaining,
+            min_compute_time: Duration::from_millis(1100),
+            move_latency: Duration::from_millis(200),
+            inc: Duration::from_millis(1000),
+        };
+
+        assert_eq!(
+            Duration::from_millis(4800),
+            timing.compute_thinking_time(20, Duration::from_secs(40))
+        );
+    }
+
+    #[test]
+    fn eq_1sec_inc_estimated_less_than_min_returns_min() {
+        let timing = Timing {
+            exp_moves_fn: dummy_half_moves_remaining,
+            min_compute_time: Duration::from_millis(1100),
+            move_latency: Duration::from_millis(200),
+            inc: Duration::from_millis(1000),
+        };
+
+        assert_eq!(
+            Duration::from_millis(1100),
+            timing.compute_thinking_time(200, Duration::from_secs(10))
+        );
+    }
+
+    #[test]
+    fn eq_1sec_inc_time_remaining_less_than_inc_buffer_returns_inc_minus_latency() {
+        let timing = Timing {
+            exp_moves_fn: dummy_half_moves_remaining,
+            min_compute_time: Duration::from_millis(100),
+            move_latency: Duration::from_millis(200),
+            inc: Duration::from_millis(1000),
+        };
+
+        assert_eq!(
+            Duration::from_millis(800),
+            timing.compute_thinking_time(200, Duration::from_secs(1))
+        );
+    }
+}


### PR DESCRIPTION
Instead of a hardcoded estimated moves we use a function which computes the expected moves left given the number of moves which have already been played as described [here](https://chess.stackexchange.com/questions/2506/what-is-the-average-length-of-a-game-of-chess). 

closes #81 