### PR TITLE
[ISSUE-57] Added support for lichess tablebase service in game-lambda

### DIFF
--- a/game-lambda/Cargo.lock
+++ b/game-lambda/Cargo.lock
@@ -1532,6 +1532,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.18.1",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio 0.2.22",
  "tokio-rustls 0.14.1",

--- a/game-lambda/Cargo.toml
+++ b/game-lambda/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "0.5.6"
 rand = "0.5.0"
 itertools = "0.8"
 tokio = { version = "0.2.22", default_features = false, features = ["rt-core"] }
-reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking"] }
+reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking", "json"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_lambda = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_dynamodb = { version = "0.45.0", default_features = false, features = ["rustls"] }

--- a/game-lambda/src/endgame.rs
+++ b/game-lambda/src/endgame.rs
@@ -1,0 +1,91 @@
+use crate::game::{InitalPosition, LookupService};
+use myopic_brain::MutBoard;
+use reqwest::{blocking, Error};
+use serde_derive::Deserialize;
+use std::time::Instant;
+use tokio::time::Duration;
+
+const TIMEOUT_MS: u64 = 1500;
+const MAX_TABLE_MISSES: usize = 2;
+const PIECE_COUNT: usize = 7;
+const TABLE_ENDPOINT: &'static str = "http://tablebase.lichess.ovh/standard";
+
+#[derive(Default)]
+pub struct EndgameService {
+    client: reqwest::blocking::Client,
+    table_misses: usize,
+}
+
+impl EndgameService {
+    fn execute_query(&self, query: &str) -> Result<blocking::Response, Error> {
+        self.client
+            .get(TABLE_ENDPOINT)
+            .query(&[("fen", query)])
+            .timeout(Duration::from_millis(TIMEOUT_MS))
+            .send()
+    }
+
+    fn process_response(&mut self, resp: blocking::Response) -> Result<Option<String>, String> {
+        resp
+            .json::<EndgameTableResponse>()
+            .map_err(|e| {
+                self.table_misses += 1;
+                log::info!("Incrementing table misses due to {}", e);
+                format!("Problem deserializing response: {}", e)
+            })
+            .and_then(|r| {
+                r.moves
+                    .get(0)
+                    .map(|sm| {
+                        log::info!("Extracted {} from endgame tables", sm.uci);
+                        Some(sm.uci.clone())
+                    })
+                    .ok_or_else(|| {
+                        self.table_misses += 1;
+                        log::info!("Incrementing table misses due to unknown position");
+                        format!("No suggested moves for position!")
+                    })
+            })
+    }
+}
+
+impl LookupService for EndgameService {
+    fn lookup_move(
+        &mut self,
+        initial_position: &InitalPosition,
+        uci_sequence: &str,
+    ) -> Result<Option<String>, String> {
+        let state = crate::position::get(initial_position, uci_sequence)?;
+        let query = state.to_fen().replace(" ", "_");
+        if self.table_misses >= MAX_TABLE_MISSES {
+            log::info!("Max misses reached, skipping table request for {}", query);
+            Ok(None)
+        } else if state.all_pieces().size() > PIECE_COUNT {
+            log::info!("Too many pieces to use endgame tables for {}", query);
+            Ok(None)
+        } else {
+            let start = Instant::now();
+            let response_result = self.execute_query(query.as_str());
+            let query_duration = start.elapsed();
+            log::info!("Endgame table query took {}ms", query_duration.as_millis());
+            match response_result {
+                Ok(response) => self.process_response(response),
+                Err(e) => {
+                    self.table_misses += 1;
+                    log::info!("Incrementing table misses due to {}", e);
+                    Err(e.to_string())
+                }
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct EndgameTableResponse {
+    moves: Vec<SuggestedMove>,
+}
+
+#[derive(Deserialize)]
+struct SuggestedMove {
+    uci: String,
+}

--- a/game-lambda/src/events.rs
+++ b/game-lambda/src/events.rs
@@ -159,7 +159,8 @@ mod test {
                 "wdraw": false,
                 "bdraw": false,
                 "status": "started"
-            }
+            },
+            "initialFen": "startpos"
         }"#;
 
         match serde_json::from_str::<GameEvent>(json) {

--- a/game-lambda/src/position.rs
+++ b/game-lambda/src/position.rs
@@ -1,0 +1,16 @@
+use crate::game::InitalPosition;
+use myopic_brain::{EvalBoardImpl, MutBoard, MutBoardImpl};
+
+pub fn get(
+    initial: &InitalPosition,
+    uci_sequence: &str,
+) -> Result<EvalBoardImpl<MutBoardImpl>, String> {
+    let mut position = match initial {
+        InitalPosition::Start => myopic_brain::pos::start(),
+        InitalPosition::CustomFen(fen) => myopic_brain::pos::from_fen(fen.as_str())?,
+    };
+    for mv in myopic_brain::parse::partial_uci(&position, uci_sequence)? {
+        position.evolve(&mv);
+    }
+    Ok(position)
+}


### PR DESCRIPTION
When there are 7 or less pieces on the board the lambda switches to making calls out to the tablebase api provided by lichess. The timeout on the request is 1500ms and if two failed requests are made then a breaker is thrown and we switch back to the compute lambda.

closes #57 