### PR TITLE
Event stream is more robust and bot is displayed online permanently

### DIFF
--- a/event-stream/Cargo.lock
+++ b/event-stream/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "pin-project-lite 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/event-stream/Cargo.toml
+++ b/event-stream/Cargo.toml
@@ -17,6 +17,6 @@ log = "0.4.11"
 bytes = "0.5.6"
 anyhow = "1.0.35"
 tokio = { version = "0.2.22", default_features = false, features = ["rt-core"] }
-reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking"] }
+reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking", "json"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_lambda = { version = "0.45.0", default_features = false, features = ["rustls"] }

--- a/event-stream/src/main.rs
+++ b/event-stream/src/main.rs
@@ -3,6 +3,7 @@ mod events;
 mod game_start;
 mod lichess;
 mod params;
+mod user_status;
 mod validity;
 
 extern crate bytes;
@@ -16,6 +17,7 @@ extern crate serde_derive;
 
 use crate::game_start::GameStartService;
 use crate::params::ApplicationParameters;
+use crate::user_status::StatusService;
 use anyhow::{Error, Result};
 use challenge::ChallengeService;
 use events::LichessEvent;
@@ -23,23 +25,32 @@ use reqwest::blocking;
 use simple_logger::SimpleLogger;
 use std::io::{BufRead, BufReader};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const EVENT_STREAM_ENDPOINT: &'static str = "https://lichess.org/api/stream/event";
+
+enum LoopAction {
+    Continue,
+    Break,
+}
 
 fn main() -> Result<()> {
     init_environment()?;
     let parameters = ApplicationParameters::load()?;
 
     loop {
-        let event_processor = EventProcessor {
+        let mut event_processor = EventProcessor {
             challenge_service: ChallengeService::new(&parameters),
             gamestart_service: GameStartService::new(&parameters),
+            status_service: StatusService::new(&parameters),
         };
 
         log::info!("Opening event stream");
         for read_result in open_event_stream(&parameters.lichess_auth_token)?.lines() {
-            event_processor.handle_stream_read(read_result)
+            match event_processor.handle_stream_read(read_result) {
+                LoopAction::Continue => continue,
+                LoopAction::Break => break,
+            }
         }
 
         log::info!(
@@ -60,61 +71,6 @@ fn init_environment() -> Result<()> {
     Ok(())
 }
 
-struct EventProcessor {
-    challenge_service: ChallengeService,
-    gamestart_service: GameStartService,
-}
-impl EventProcessor {
-    fn handle_stream_read(&self, read_result: std::io::Result<String>) {
-        match read_result {
-            Err(read_error) => log::warn!("Stream read error: {}", read_error),
-            Ok(line) => {
-                if !line.trim().is_empty() {
-                    match serde_json::from_str::<LichessEvent>(line.as_str()) {
-                        Err(parse_error) => log::warn!("Parse error: {}", parse_error),
-                        Ok(event) => match event {
-                            LichessEvent::Challenge { challenge } => {
-                                // Idea now is in processing the challenge we simply accept it or not
-                                // and we do not start the lambda function
-
-                                log::info!("Received challenge event: {}", line);
-                                match self.challenge_service.process_challenge(challenge) {
-                                    Ok(message) => {
-                                        log::info!("Processed challenge with message: {}", message)
-                                    }
-                                    Err(error) => {
-                                        log::warn!("Error processing challenge: {}", error)
-                                    }
-                                }
-                            }
-                            LichessEvent::GameStart { game } => {
-                                // When we receive the game start we query lichess for game stream
-                                // and get the gameFull json first line. We close the stream and
-                                // check the parameters before either starting lambda or aborting
-                                // game.
-                                //
-                                // Or we could get the list of all games in progress if we didn't
-                                // want to open the stream, only problem here is it limits you to
-                                // 49 concurrent games.
-
-                                log::info!("Received game start event: {}", line);
-                                match self.gamestart_service.process_gamestart(game) {
-                                    Ok(message) => {
-                                        log::info!("Processed gamestart with message: {}", message)
-                                    }
-                                    Err(error) => {
-                                        log::warn!("Error processing gamestart: {}", error)
-                                    }
-                                }
-                            }
-                        },
-                    }
-                }
-            }
-        }
-    }
-}
-
 fn open_event_stream(auth_token: &String) -> Result<BufReader<blocking::Response>> {
     blocking::Client::new()
         .get(EVENT_STREAM_ENDPOINT)
@@ -122,4 +78,68 @@ fn open_event_stream(auth_token: &String) -> Result<BufReader<blocking::Response
         .send()
         .map(|response| BufReader::new(response))
         .map_err(Error::from)
+}
+
+struct EventProcessor {
+    challenge_service: ChallengeService,
+    gamestart_service: GameStartService,
+    status_service: StatusService,
+}
+impl EventProcessor {
+    fn handle_stream_read(&mut self, read_result: std::io::Result<String>) -> LoopAction {
+        match read_result {
+            Err(read_error) => {
+                log::warn!("Stream read error: {}", read_error);
+                LoopAction::Break
+            }
+            Ok(line) => {
+                if line.trim().is_empty() {
+                    self.user_status()
+                } else {
+                    match serde_json::from_str::<LichessEvent>(line.as_str()) {
+                        Err(parse_error) => log::warn!("Parse error: {}", parse_error),
+                        Ok(event) => {
+                            log::info!("Received event: {}", line.as_str());
+                            self.handle_event(event)
+                        }
+                    };
+                    LoopAction::Continue
+                }
+            }
+        }
+    }
+
+    fn user_status(&mut self) -> LoopAction {
+        match self.status_service.user_status() {
+            Err(e) => {
+                log::warn!("Error fetching user status: {}", e);
+                LoopAction::Continue
+            }
+            Ok(None) => LoopAction::Continue,
+            Ok(Some(status)) => {
+                if status.online {
+                    LoopAction::Continue
+                } else {
+                    LoopAction::Break
+                }
+            }
+        }
+    }
+
+    fn handle_event(&self, event: LichessEvent) {
+        match event {
+            LichessEvent::Challenge { challenge } => {
+                match self.challenge_service.process_challenge(challenge) {
+                    Ok(message) => log::info!("Processed challenge with message: {}", message),
+                    Err(error) => log::warn!("Error processing challenge: {}", error),
+                }
+            }
+            LichessEvent::GameStart { game } => {
+                match self.gamestart_service.process_gamestart(game) {
+                    Ok(message) => log::info!("Processed gamestart with message: {}", message),
+                    Err(error) => log::warn!("Error processing gamestart: {}", error),
+                }
+            }
+        }
+    }
 }

--- a/event-stream/src/main.rs
+++ b/event-stream/src/main.rs
@@ -46,7 +46,14 @@ fn main() -> Result<()> {
         };
 
         log::info!("Opening event stream");
+        let start = Instant::now();
         for read_result in open_event_stream(&parameters.lichess_auth_token)?.lines() {
+            let elapsed = start.elapsed();
+            let max_stream_duration = Duration::from_secs(parameters.max_stream_life_mins * 60);
+            if start.elapsed() > max_stream_duration {
+                log::info!("Refreshing event stream which has been alive for {} mins", elapsed.as_secs() / 60);
+                break;
+            }
             match event_processor.handle_stream_read(read_result) {
                 LoopAction::Continue => continue,
                 LoopAction::Break => break,

--- a/event-stream/src/params.rs
+++ b/event-stream/src/params.rs
@@ -23,6 +23,7 @@ const MYOPIC_MAX_LAMBDA_DURATION_MINS: &'static str = "MYOPIC_MAX_LAMBDA_DURATIO
 const MYOPIC_INCREMENT_ALLOWANCE_MINS: &'static str = "MYOPIC_INCREMENT_ALLOWANCE_MINS";
 const MYOPIC_RETRY_WAIT_DURATION_SECS: &'static str = "MYOPIC_RETRY_WAIT_DURATION_SECS";
 const MYOPIC_ABORT_AFTER_SECS: &'static str = "MYOPIC_ABORT_AFTER_SECS";
+const MYOPIC_STATUS_POLL_GAP_SECS: &'static str = "MYOPIC_STATUS_POLL_GAP_SECS";
 
 #[derive(Debug, Clone)]
 pub struct ApplicationParameters {
@@ -43,6 +44,7 @@ pub struct ApplicationParameters {
     pub increment_allowance_mins: u8,
     pub retry_wait_duration_secs: u64,
     pub abort_after_secs: usize,
+    pub status_poll_gap_secs: usize,
 }
 
 impl ApplicationParameters {
@@ -65,6 +67,7 @@ impl ApplicationParameters {
             increment_allowance_mins: env::var(MYOPIC_INCREMENT_ALLOWANCE_MINS)?.parse()?,
             retry_wait_duration_secs: env::var(MYOPIC_RETRY_WAIT_DURATION_SECS)?.parse()?,
             abort_after_secs: env::var(MYOPIC_ABORT_AFTER_SECS)?.parse()?,
+            status_poll_gap_secs: env::var(MYOPIC_STATUS_POLL_GAP_SECS)?.parse()?,
         })
     }
 

--- a/event-stream/src/params.rs
+++ b/event-stream/src/params.rs
@@ -24,6 +24,7 @@ const MYOPIC_INCREMENT_ALLOWANCE_MINS: &'static str = "MYOPIC_INCREMENT_ALLOWANC
 const MYOPIC_RETRY_WAIT_DURATION_SECS: &'static str = "MYOPIC_RETRY_WAIT_DURATION_SECS";
 const MYOPIC_ABORT_AFTER_SECS: &'static str = "MYOPIC_ABORT_AFTER_SECS";
 const MYOPIC_STATUS_POLL_GAP_SECS: &'static str = "MYOPIC_STATUS_POLL_GAP_SECS";
+const MYOPIC_MAX_STREAM_LIFE_MINS: &'static str = "MYOPIC_MAX_STREAM_LIFE_MINS";
 
 #[derive(Debug, Clone)]
 pub struct ApplicationParameters {
@@ -43,8 +44,9 @@ pub struct ApplicationParameters {
     pub max_lambda_duration_mins: u8,
     pub increment_allowance_mins: u8,
     pub retry_wait_duration_secs: u64,
-    pub abort_after_secs: usize,
-    pub status_poll_gap_secs: usize,
+    pub abort_after_secs: u64,
+    pub status_poll_gap_secs: u64,
+    pub max_stream_life_mins: u64,
 }
 
 impl ApplicationParameters {
@@ -68,6 +70,7 @@ impl ApplicationParameters {
             retry_wait_duration_secs: env::var(MYOPIC_RETRY_WAIT_DURATION_SECS)?.parse()?,
             abort_after_secs: env::var(MYOPIC_ABORT_AFTER_SECS)?.parse()?,
             status_poll_gap_secs: env::var(MYOPIC_STATUS_POLL_GAP_SECS)?.parse()?,
+            max_stream_life_mins: env::var(MYOPIC_MAX_STREAM_LIFE_MINS)?.parse()?,
         })
     }
 
@@ -129,5 +132,5 @@ struct PlayGameEvent {
     /// How many seconds to wait for the first full move to take place
     /// before aborting the game
     #[serde(rename = "abortAfterSecs")]
-    abort_after_secs: usize,
+    abort_after_secs: u64,
 }

--- a/event-stream/src/user_status.rs
+++ b/event-stream/src/user_status.rs
@@ -1,0 +1,97 @@
+use crate::params::ApplicationParameters;
+use anyhow::{anyhow, Error, Result};
+use std::time::Instant;
+use tokio::time::Duration;
+
+const STATUS_ENDPOINT: &'static str = "https://lichess.org/api/users/status";
+
+pub struct StatusService {
+    client: StatusClient,
+    status_poll_gap: Duration,
+    status_checkpoint: Instant,
+    user_id: String,
+}
+
+impl StatusService {
+    pub fn new(parameters: &ApplicationParameters) -> StatusService {
+        StatusService {
+            client: StatusClient::default(),
+            status_poll_gap: Duration::from_secs(parameters.status_poll_gap_secs as u64),
+            status_checkpoint: Instant::now(),
+            user_id: parameters.lichess_bot_id.to_string(),
+        }
+    }
+
+    pub fn user_status(&mut self) -> Result<Option<UserStatus>> {
+        if self.status_checkpoint.elapsed() > self.status_poll_gap {
+            self.status_checkpoint = Instant::now();
+            self.client
+                .user_status(self.user_id.as_str())
+                .map(|status| Some(status))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Default)]
+struct StatusClient {
+    inner: reqwest::blocking::Client,
+}
+
+impl StatusClient {
+    pub fn user_status(&self, users: &str) -> Result<UserStatus> {
+        self.inner
+            .get(STATUS_ENDPOINT)
+            .query(&[("ids", users)])
+            .send()
+            .and_then(|r| r.json::<Vec<UserStatus>>())
+            .map_err(Error::from)
+            .and_then(|xs| {
+                xs.first()
+                    .cloned()
+                    .ok_or(anyhow!("No statuses for {}", users))
+            })
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct UserStatus {
+    pub id: String,
+    #[serde(default)]
+    pub online: bool,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::user_status::UserStatus;
+    use anyhow::Result;
+
+    #[test]
+    fn deserialize_with_flag_absent() -> Result<()> {
+        assert_eq!(
+            vec![UserStatus {
+                id: "id".to_string(),
+                online: false
+            }],
+            serde_json::from_str::<Vec<UserStatus>>(r#"[{"id": "id"}]"#)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_with_flag_present() -> Result<()> {
+        let json = r#"[{
+            "id": "id",
+            "online": true
+        }]"#;
+        assert_eq!(
+            vec![UserStatus {
+                id: "id".to_string(),
+                online: true
+            }],
+            serde_json::from_str::<Vec<UserStatus>>(json)?
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
We now periodically refresh the stream instead of waiting for the server to close it with an error before refreshing. We also periodically query the API to check that it still considers the bot to be online. If it shows offline then we refresh the connection.

closes #93 